### PR TITLE
Pin timezonefinder requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ configuration files. If running under Termux and `termux-location` is
 available, that tool is used as a last resort to retrieve coordinates. The
 timezone is automatically determined from the resolved coordinates using the
 `timezonefinder` library, so only latitude and longitude need to be provided.
+
+The dependencies are listed in `requirements.txt`. The
+`timezonefinder` package is pinned below version 6 so that a pure-Python
+implementation is installed by default.

--- a/location.py
+++ b/location.py
@@ -51,7 +51,6 @@ def _termux_location() -> tuple[str | None, str | None]:
     return None, None
 
 
-
 def get_location(
     lat: float | None = None, lon: float | None = None, timezone: str | None = None
 ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 astral
-timezonefinder
+timezonefinder<6


### PR DESCRIPTION
## Summary
- pin timezonefinder to `<6` in `requirements.txt`
- note that timezonefinder is pinned so the pure-Python version is installed
- run black formatting

## Testing
- `black --check .`

------
https://chatgpt.com/codex/tasks/task_e_68584c2827c48325b146f06d55d40dcb